### PR TITLE
Use paging instead of stacking tiles when web part is resized

### DIFF
--- a/src/webparts/userModal/components/UserModal.module.scss
+++ b/src/webparts/userModal/components/UserModal.module.scss
@@ -40,7 +40,7 @@
 
 .gridTwo, .gridThree, .gridFour {
   flex-wrap: nowrap;
-  justify-content: space-around;
+  justify-content: space-between;
   
   .tileContainer {
     flex: 0 0 auto;

--- a/src/webparts/userModal/components/UserModal.module.scss
+++ b/src/webparts/userModal/components/UserModal.module.scss
@@ -26,6 +26,7 @@
   width: 100%;
   margin: 0;
   padding: 0;
+  flex-wrap: nowrap; /* Prevent wrapping to keep layout consistent */
 }
 
 .gridOne {
@@ -34,62 +35,13 @@
   }
 }
 
-.gridTwo {
-  @media (max-width: 768px) {
-    flex-direction: column;
-    align-items: center;
-    
-    .tileContainer {
-      margin-bottom: 20px;
-    }
-  }
-}
-
-.gridThree {
-  @media (max-width: 992px) {
-    flex-wrap: wrap;
-    
-    .tileContainer {
-      width: 45%;
-      margin-bottom: 20px;
-    }
-  }
+.gridTwo, .gridThree, .gridFour {
+  flex-wrap: nowrap;
+  justify-content: space-around;
   
-  @media (max-width: 768px) {
-    flex-direction: column;
-    align-items: center;
-    
-    .tileContainer {
-      width: 100%;
-      margin-bottom: 20px;
-    }
-  }
-}
-
-.gridFour {
-  @media (max-width: 1200px) {
-    flex-wrap: wrap;
-    
-    .tileContainer {
-      width: 30%;
-      margin-bottom: 20px;
-    }
-  }
-  
-  @media (max-width: 992px) {
-    .tileContainer {
-      width: 45%;
-    }
-  }
-  
-  @media (max-width: 768px) {
-    flex-direction: column;
-    align-items: center;
-    
-    .tileContainer {
-      width: 100%;
-      margin-bottom: 20px;
-    }
+  .tileContainer {
+    flex: 0 0 auto;
+    margin: 0 10px;
   }
 }
 
@@ -215,6 +167,11 @@
   padding: 40px 0;
   color: #666;
   font-style: italic;
+}
+
+/* Always show navigation controls when there are multiple pages */
+.alwaysShowNavigation {
+  display: flex !important;
 }
 
 /* Modal Styles */

--- a/src/webparts/userModal/components/UserModal.tsx
+++ b/src/webparts/userModal/components/UserModal.tsx
@@ -12,43 +12,115 @@ export default class UserModal extends React.Component<IUserModalProps, {
   currentPage: number;
   isModalOpen: boolean;
   selectedUser: IUserItem | null;
+  containerWidth: number;
+  effectiveItemsPerPage: number;
 }> {
   
+  private _containerRef: React.RefObject<HTMLDivElement>;
+  private _resizeObserver: ResizeObserver | null = null;
+
   constructor(props: IUserModalProps) {
     super(props);
     this.state = {
       currentPage: 0,
       isModalOpen: false,
-      selectedUser: null
+      selectedUser: null,
+      containerWidth: 0,
+      effectiveItemsPerPage: props.itemsPerPage
     };
+    this._containerRef = React.createRef();
+  }
+
+  public componentDidMount(): void {
+    if (this._containerRef.current) {
+      // Initialize with current width
+      this.setState({ 
+        containerWidth: this._containerRef.current.clientWidth
+      }, () => {
+        this._calculateItemsPerPage();
+      });
+
+      // Set up ResizeObserver to monitor container width changes
+      this._resizeObserver = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          if (entry.target === this._containerRef.current) {
+            this.setState({ containerWidth: entry.contentRect.width }, () => {
+              this._calculateItemsPerPage();
+            });
+          }
+        }
+      });
+      
+      this._resizeObserver.observe(this._containerRef.current);
+    }
+  }
+
+  public componentWillUnmount(): void {
+    // Clean up the ResizeObserver when component unmounts
+    if (this._resizeObserver && this._containerRef.current) {
+      this._resizeObserver.unobserve(this._containerRef.current);
+      this._resizeObserver.disconnect();
+    }
+  }
+
+  private _calculateItemsPerPage(): void {
+    const { containerWidth } = this.state;
+    const { itemsPerPage } = this.props;
+    
+    // Set tile widths based on configuration
+    let tileWidth = 180; // 160px + margins (approximate)
+
+    // Default to the configured itemsPerPage
+    let effectiveItemsPerPage = itemsPerPage;
+    
+    // Calculate how many items can fit based on container width
+    const canFit = Math.floor(containerWidth / tileWidth);
+    
+    // If container is too small to fit all configured items, reduce number shown
+    if (canFit < itemsPerPage && canFit > 0) {
+      effectiveItemsPerPage = canFit;
+    }
+    
+    // Update state only if value changed
+    if (this.state.effectiveItemsPerPage !== effectiveItemsPerPage) {
+      this.setState({ 
+        effectiveItemsPerPage,
+        // Reset to first page when items per page changes
+        currentPage: 0
+      });
+    }
   }
 
   public render(): React.ReactElement<IUserModalProps> {
     const { 
       userItems, 
       isLoading, 
-      itemsPerPage,
       hasTeamsContext,
       isDarkTheme
     } = this.props;
 
-    const { currentPage, isModalOpen, selectedUser } = this.state;
+    const { 
+      currentPage, 
+      isModalOpen, 
+      selectedUser, 
+      effectiveItemsPerPage 
+    } = this.state;
     
-    // Calculate total pages
-    const totalPages = Math.ceil(userItems.length / itemsPerPage);
+    // Calculate total pages based on effectiveItemsPerPage
+    const totalPages = Math.ceil(userItems.length / effectiveItemsPerPage);
     
     // Get items for current page
-    const startIndex = currentPage * itemsPerPage;
-    const endIndex = startIndex + itemsPerPage;
+    const startIndex = currentPage * effectiveItemsPerPage;
+    const endIndex = startIndex + effectiveItemsPerPage;
     const currentItems = userItems.slice(startIndex, endIndex);
     
-    // Generate grid class based on items per page
+    // Generate grid class based on effective items per page
     let gridClass = styles.gridOne;
-    if (itemsPerPage === 2) {
+    if (effectiveItemsPerPage === 2) {
       gridClass = styles.gridTwo;
-    } else if (itemsPerPage === 3) {
+    } else if (effectiveItemsPerPage === 3) {
       gridClass = styles.gridThree;
-    } else if (itemsPerPage === 4) {
+    } else if (effectiveItemsPerPage === 4) {
       gridClass = styles.gridFour;
     }
 
@@ -78,7 +150,10 @@ export default class UserModal extends React.Component<IUserModalProps, {
     };
 
     return (
-      <div className={`${styles.userModal} ${hasTeamsContext ? styles.teams : ''}`}>
+      <div 
+        className={`${styles.userModal} ${hasTeamsContext ? styles.teams : ''}`}
+        ref={this._containerRef}
+      >
         <div className={styles.container}>
           {isLoading ? (
             <div className={styles.spinner}>
@@ -101,8 +176,9 @@ export default class UserModal extends React.Component<IUserModalProps, {
                 ))}
               </div>
               
+              {/* Always show navigation controls if there are multiple pages */}
               {totalPages > 1 && (
-                <div className={styles.navigationControls}>
+                <div className={`${styles.navigationControls} ${styles.alwaysShowNavigation}`}>
                   <button 
                     className={`${styles.navButton} ${currentPage === 0 ? styles.disabled : ''}`}
                     onClick={goToPreviousPage}


### PR DESCRIPTION
## Changes

This PR modifies the User Modal web part to use paging instead of responsive stacking when the web part is resized.

### Problem

Currently, when the web part is resized to smaller widths, the CSS media queries cause the tiles to stack vertically. This creates an inconsistent layout experience across different screen sizes.

### Solution

1. **Removed Responsive Stacking:** Removed media queries that cause tiles to stack vertically on smaller screens.
2. **Dynamic Paging:** Implemented a ResizeObserver to detect container width changes.
3. **Adaptive Tile Count:** Dynamically calculate how many tiles can fit in the current width and adjust the pagination accordingly.

### Benefits

- Consistent layout regardless of screen size (tiles never stack)
- Improved user experience with automatic pagination based on available space
- Maintains the original grid layout for all screen sizes

### Testing

- Verified that tiles maintain their layout when resizing the web part
- Confirmed that pagination controls automatically appear when needed
- Tested across different initial configurations (1-4 tiles per view)
