### PR TITLE
Fix carousel container overflow on small screens

### DIFF
--- a/src/webparts/userModal/components/UserModal.module.scss
+++ b/src/webparts/userModal/components/UserModal.module.scss
@@ -47,7 +47,7 @@
 }
 
 .gridTwo, .gridThree, .gridFour {
-  justify-content: space-around; /* Better spacing for responsive layouts */
+  justify-content: space-between; /* Better spacing for responsive layouts */
   
   .tileContainer {
     flex: 0 0 auto;

--- a/src/webparts/userModal/components/UserModal.module.scss
+++ b/src/webparts/userModal/components/UserModal.module.scss
@@ -7,6 +7,8 @@
     font-family: $ms-font-family-fallbacks;
   }
   overflow-x: hidden; /* Prevent horizontal overflow at the root level */
+  width: 100%; /* Ensure the component takes full width of its container */
+  box-sizing: border-box;
 }
 
 .container {
@@ -15,6 +17,7 @@
   max-width: 100%;
   margin: 0 auto; /* Center the container */
   box-sizing: border-box;
+  overflow: hidden; /* Prevent any children from overflowing */
 }
 
 .carouselContainer {
@@ -22,35 +25,50 @@
   width: 100%;
   overflow: hidden; /* Prevent content from overflowing */
   box-sizing: border-box;
+  margin: 0 auto; /* Center the carousel */
 }
 
 .tilesGrid {
   display: flex;
-  justify-content: center; /* Changed from space-between to center for better small screen layout */
+  justify-content: center; /* Center tiles for better small screen layout */
   width: 100%;
   margin: 0;
   padding: 0;
-  flex-wrap: nowrap; /* Prevent wrapping to keep layout consistent */
+  flex-wrap: nowrap; /* Keep layout consistent */
+  box-sizing: border-box;
+  min-width: 0; /* Fix flexbox min-width issue in some browsers */
 }
 
 .gridOne {
   .tileContainer {
     margin: 0 auto;
+    max-width: 100%; /* Ensure single tile doesn't overflow */
   }
 }
 
 .gridTwo, .gridThree, .gridFour {
-  flex-wrap: nowrap;
   justify-content: space-around; /* Better spacing for responsive layouts */
   
   .tileContainer {
     flex: 0 0 auto;
     margin: 0 10px;
+    /* Adjust width to prevent overflow */
+    max-width: calc(50% - 20px); /* For 2 tiles layout */
   }
 }
 
+/* Specific adjustments for 3 and 4 tiles */
+.gridThree .tileContainer {
+  max-width: calc(33.33% - 20px); /* For 3 tiles layout */
+}
+
+.gridFour .tileContainer {
+  max-width: calc(25% - 20px); /* For 4 tiles layout */
+}
+
 .tileContainer {
-  width: 160px;
+  width: 160px; /* Default width */
+  max-width: 100%; /* Ensure responsiveness */
   display: flex;
   flex-direction: column;
   text-align: center;
@@ -63,6 +81,7 @@
   position: relative;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
 
   &:hover {
     transform: scale(1.05);
@@ -71,6 +90,9 @@
 
 .imageContainer {
   margin-bottom: 16px;
+  width: 100%; /* Make image container responsive */
+  display: flex;
+  justify-content: center;
 }
 
 .contentContainer {
@@ -79,6 +101,9 @@
   flex-direction: column;
   align-items: left;
   justify-content: left;
+  width: 100%; /* Full width */
+  min-width: 0; /* Allow text truncation to work properly */
+  overflow: hidden; /* Hide overflowing text */
 }
 
 .title {
@@ -88,6 +113,9 @@
   margin-bottom: 5px;
   color: #333;
   text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .position {
@@ -95,6 +123,9 @@
   color: #666;
   margin: 0 0 5px 0;
   text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .arrowIcon {
@@ -108,6 +139,7 @@
   justify-content: center;
   align-items: center;
   margin-top: 15px;
+  width: 100%; /* Full width to align properly */
 }
 
 .navButton {

--- a/src/webparts/userModal/components/UserModal.tsx
+++ b/src/webparts/userModal/components/UserModal.tsx
@@ -66,32 +66,32 @@ export default class UserModal extends React.Component<IUserModalProps, {
     const { containerWidth } = this.state;
     const { itemsPerPage } = this.props;
     
-    // Set tile width including margins and padding
-    const tileWidth = 180; // 160px width + 20px margins
+    // More responsive approach to calculate tile width based on container size
+    // Base tile width plus margins (adjusted from 180px to account for different screen sizes)
+    const baseTileWidth = 160; // Base width of tile
+    const tileMargins = 20; // Left + right margins
+    const minTileWidth = baseTileWidth + tileMargins; // Minimum width needed for a tile
     
-    // Account for container padding (40px total: 20px left + 20px right)
-    const availableWidth = containerWidth - 40;
+    // Account for container padding (left + right)
+    const containerPadding = 40; // 20px on each side
+    const availableWidth = Math.max(minTileWidth, containerWidth - containerPadding);
     
-    // Default to the configured itemsPerPage
-    let effectiveItemsPerPage = itemsPerPage;
+    // Determine how many tiles can fit based on available width
+    // Adding a small buffer to prevent edge cases
+    const buffer = 5;
+    const canFit = Math.max(1, Math.floor((availableWidth - buffer) / minTileWidth));
     
-    // Calculate how many items can fit based on available width
-    // Math.max ensures we always show at least 1 item
-    const canFit = Math.max(1, Math.floor(availableWidth / tileWidth));
+    // Calculate effective items per page but don't exceed configured maximum
+    let effectiveItemsPerPage = Math.min(canFit, itemsPerPage);
     
-    // If container is too small to fit all configured items, reduce number shown
-    if (canFit < itemsPerPage) {
-      effectiveItemsPerPage = canFit;
-    }
-    
-    // Cap the maximum at the configured itemsPerPage
-    effectiveItemsPerPage = Math.min(effectiveItemsPerPage, itemsPerPage);
+    // Ensure we always show at least 1 item
+    effectiveItemsPerPage = Math.max(1, effectiveItemsPerPage);
     
     // Update state only if value changed
     if (this.state.effectiveItemsPerPage !== effectiveItemsPerPage) {
       this.setState({ 
         effectiveItemsPerPage,
-        // Reset to first page when items per page changes
+        // Reset to first page when items per page changes to avoid showing empty pages
         currentPage: 0
       });
     }

--- a/src/webparts/userModal/components/UserTile.tsx
+++ b/src/webparts/userModal/components/UserTile.tsx
@@ -24,14 +24,20 @@ const UserTile: React.FC<IUserTileProps> = (props) => {
         }
       }}
     >
-      <Persona
-        className={styles.imageContainer}
-        imageUrl={item.photoUrl}
-        size={PersonaSize.size72}
-      />
+      <div className={styles.imageContainer}>
+        <Persona
+          imageUrl={item.photoUrl}
+          size={PersonaSize.size72}
+          imageAlt={`Profile photo of ${item.title}`}
+        />
+      </div>
       <div className={styles.contentContainer}>
-        <h3 className={styles.title}>{escape(item.title)}</h3>
-        <p className={styles.position}>{escape(item.position)}</p>
+        <h3 className={styles.title} title={item.title}>
+          {escape(item.title)}
+        </h3>
+        <p className={styles.position} title={item.position}>
+          {escape(item.position)}
+        </p>
         <div className={styles.arrowIcon}>
           <Icon iconName="ChromeBackMirrored" />
         </div>


### PR DESCRIPTION
## Problem
The carousel container in the User Modal web part was overflowing its width when displayed on smaller screens, causing horizontal scrollbars or content being cut off.

## Root Causes
1. The use of `flex-wrap: nowrap` prevented tiles from adapting to smaller screens
2. Fixed tile widths that didn't adjust responsively 
3. Calculation logic for items per page didn't accurately account for all layout factors
4. Text in user tiles wasn't properly truncated with ellipsis

## Changes Made
### CSS Improvements:
- Added proper `overflow: hidden` and `box-sizing: border-box` to key containers
- Made tiles responsive with percentage-based max-widths for different grid layouts
- Added text truncation with ellipsis for titles and positions
- Added proper container sizing to prevent overflow
- Applied specific max-width calculations for different grid layouts (2, 3, or 4 tiles)

### JavaScript Improvements:
- Improved the `_calculateItemsPerPage()` logic with better size calculations
- Added a small buffer to prevent edge cases in calculations
- Improved handling of tiny screen sizes

### UserTile Component:
- Added proper wrapping and structure for the Persona component
- Added title attributes to show full text on hover
- Added proper accessibility attributes for images

## Testing
This fix ensures that:
- The carousel adapts properly to different screen sizes
- No horizontal scrollbars appear on small screens
- The content is always contained within the web part's width
- Text is truncated with ellipsis when needed
- The correct number of tiles are shown based on available width

This approach maintains the web part's design while making it fully responsive.